### PR TITLE
Fix overlay argument names

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,29 +1,29 @@
-self: super: {
+final: prev: {
   ada =
-    self.haskell.lib.justStaticExecutables
-      self.haskellPackages.ada;
+    final.haskell.lib.justStaticExecutables
+      final.haskellPackages.ada;
 
-  haskellPackages = super.haskellPackages.override (old: {
+  haskellPackages = prev.haskellPackages.override (old: {
     overrides =
-      self.lib.fold
-        self.lib.composeExtensions
+      final.lib.fold
+        final.lib.composeExtensions
         (old.overrides or (_: _: { }))
-        [ (self.haskell.lib.packageSourceOverrides {
+        [ (final.haskell.lib.packageSourceOverrides {
             ada = ./.;
 
             base16 = "1.0";
           })
-          (hself: hsuper: {
+          (hfinal: hprev: {
             skews =
-              self.haskell.lib.dontCheck
-                (self.haskell.lib.unmarkBroken hsuper.skews);
+              final.haskell.lib.dontCheck
+                (final.haskell.lib.unmarkBroken hprev.skews);
 
             kdt =
-              self.haskell.lib.dontCheck
-                (self.haskell.lib.unmarkBroken hsuper.kdt);
+              final.haskell.lib.dontCheck
+                (final.haskell.lib.unmarkBroken hprev.kdt);
 
             wss-client =
-              self.haskell.lib.unmarkBroken hsuper.wss-client;
+              final.haskell.lib.unmarkBroken hprev.wss-client;
           })
         ];
   });


### PR DESCRIPTION
`nix flake check` is extremely petty and insists that the argument names are `final` and `prev`.  I hate this.