### PR TITLE
Ignore messages from herself

### DIFF
--- a/Slack.hs
+++ b/Slack.hs
@@ -117,6 +117,7 @@ data Event = Event
     { ts :: Text
     , channel :: Text
     , text :: Text
+    , user :: Text
     } deriving stock (Generic, Show)
       deriving anyclass (FromJSON)
 


### PR DESCRIPTION
As part of supporting direct messages to Ada, we have to make sure she ignores her own messages.  Otherwise what happens is that she receives webhooks for own replies to direct messages and keeps replying to herself.