### PR TITLE
Improve resilience of indexing

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -415,6 +415,7 @@ data AdaException
     | ConnectionFailure
     | InvalidJSON{ bytes :: ByteString, jsonError :: Text }
     | TokenizationFailure{ text :: Text }
+    | EmbeddingFailure{ input :: Vector Text, exception :: ClientError }
     deriving stock (Show)
 
 instance Exception AdaException where
@@ -453,6 +454,20 @@ instance Exception AdaException where
         Text: #{show text}
     |]
 
+    displayException EmbeddingFailure{..} = [__i|
+        Failed to embed text
+
+        One of the following text values:
+
+        #{entries}
+
+        … failed to embed with the following error:
+
+        #{Exception.displayException exception}
+    |]
+      where
+        entries = Text.unlines (map ("• " <>) (Vector.toList input))
+
 healthCheck :: Application -> Application
 healthCheck application request respond
     | Wai.pathInfo request == [ "health" ] = do
@@ -486,7 +501,7 @@ main = Logging.withStderrLogging do
           where
             header = "Bearer " <> openAIAPIKey
 
-    let embed input = do
+    let embed input = Exception.handle handler do
             let embeddingRequest = EmbeddingRequest{..}
                   where
                     model = embeddingModel
@@ -498,6 +513,14 @@ main = Logging.withStderrLogging do
             let combine content Embedding{..} = IndexedContent{..}
 
             return (Vector.zipWith combine input data_)
+          where
+            handler :: ClientError -> ClientM (Vector IndexedContent)
+            handler exception = liftIO do
+                let embeddingFailure = EmbeddingFailure{ input, .. }
+
+                Logging.warn (Text.pack (Exception.displayException embeddingFailure))
+
+                mempty
 
     let prepare = do
             indexedContents <- Serialise.readFileDeserialise store

--- a/Main.hs
+++ b/Main.hs
@@ -467,7 +467,17 @@ instance Exception AdaException where
         #{Exception.displayException exception}
     |]
       where
-        entries = Text.unlines (map ("• " <>) (Vector.toList input))
+        entries = Text.unlines (map toEntry (Vector.toList input))
+
+        toEntry text
+            | len <= 76 = "• \"" <> text <> "\""
+            | otherwise = "• \"" <> prefix <> "…" <> suffix <> "\""
+          where
+            len = Text.length text
+
+            prefix = Text.take 38 text
+
+            suffix = Text.takeEnd 37 text
 
 healthCheck :: Application -> Application
 healthCheck application request respond

--- a/Main.hs
+++ b/Main.hs
@@ -72,6 +72,7 @@ import qualified Control.Concurrent as Concurrent
 import qualified Control.Exception.Safe as Exception
 import qualified Control.Logging as Logging
 import qualified Control.Monad as Monad
+import qualified Control.Monad.Except as Except
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import qualified Data.KdTree.Static as KdTree
@@ -501,7 +502,7 @@ main = Logging.withStderrLogging do
           where
             header = "Bearer " <> openAIAPIKey
 
-    let embed input = Exception.handle handler do
+    let embed input = Except.handleError handler do
             let embeddingRequest = EmbeddingRequest{..}
                   where
                     model = embeddingModel

--- a/ada.cabal
+++ b/ada.cabal
@@ -31,6 +31,7 @@ executable ada
     , http-types
     , kdt
     , logging
+    , mtl
     , optparse-applicative
     , pretty-show
     , repline


### PR DESCRIPTION
There are still a couple of cases where the `tiktoken` Haskell package disagrees with the Python `tiktoken` package on the token count.  To handle that we now log an embedding failure as a warning instead of dying to handle that gracefully until it is fixed.